### PR TITLE
feat: add basic node linking

### DIFF
--- a/teammapper-frontend/src/app/core/models/link.model.ts
+++ b/teammapper-frontend/src/app/core/models/link.model.ts
@@ -1,0 +1,9 @@
+/**
+ * Basic link connecting two nodes on the map.
+ * Each link is unique through its id.
+ */
+export interface Link {
+  id: string; // id of the link (usually from-to)
+  from: string; // id of the first node
+  to: string; // id of the second node
+}

--- a/teammapper-frontend/src/app/core/services/links/links.service.ts
+++ b/teammapper-frontend/src/app/core/services/links/links.service.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { Link } from '../../models/link.model';
+import { StorageService } from '../storage/storage.service';
+
+/**
+ * Keeps links between nodes in memory and in the browser storage.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class LinksService {
+  private mapId: string; // id of the current map
+
+  // current list of links
+  private linksSubject = new BehaviorSubject<Link[]>([]);
+  public links$: Observable<Link[]> = this.linksSubject.asObservable();
+
+  // true when user is in "link mode"
+  private linkModeSubject = new BehaviorSubject<boolean>(false);
+  public linkMode$ = this.linkModeSubject.asObservable();
+
+  constructor(private storage: StorageService) {}
+
+  /** Set the map id and load stored links for this map. */
+  public async setMapId(id: string): Promise<void> {
+    this.mapId = id;
+    const stored = (await this.storage.get(this.storageKey())) as Link[];
+    this.linksSubject.next(stored || []);
+  }
+
+  /** Toggle link mode on or off. */
+  public toggleLinkMode(): void {
+    const current = this.linkModeSubject.getValue();
+    this.linkModeSubject.next(!current);
+  }
+
+  /** Quick check if link mode is active. */
+  public isLinkModeActive(): boolean {
+    return this.linkModeSubject.getValue();
+  }
+
+  /** Add a link from one node to another. */
+  public addLink(from: string, to: string): void {
+    if (from === to) return; // no self link
+
+    // sort ids so A-B and B-A are treated the same
+    if (from > to) [from, to] = [to, from];
+    const id = `${from}-${to}`;
+
+    const links = this.linksSubject.getValue();
+    if (links.find(l => l.id === id)) return; // avoid duplicates
+
+    const newLinks = [...links, { id, from, to }];
+    this.linksSubject.next(newLinks);
+    this.save(newLinks);
+  }
+
+  /** Remove a link by its id. */
+  public removeLink(id: string): void {
+    const newLinks = this.linksSubject.getValue().filter(l => l.id !== id);
+    this.linksSubject.next(newLinks);
+    this.save(newLinks);
+  }
+
+  /** Save links to storage using map id. */
+  private async save(links: Link[]): Promise<void> {
+    if (!this.mapId) return;
+    await this.storage.set(this.storageKey(), links);
+  }
+
+  private storageKey(): string {
+    return `links-${this.mapId}`;
+  }
+}

--- a/teammapper-frontend/src/app/modules/application/application.module.ts
+++ b/teammapper-frontend/src/app/modules/application/application.module.ts
@@ -20,6 +20,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { DialogImportMermaidComponent } from './components/dialog-import-mermaid/dialog-import-mermaid.component';
+import { LinksLayerComponent } from './components/links-layer/links-layer.component';
 
 @NgModule({
   imports: [
@@ -41,6 +42,7 @@ import { DialogImportMermaidComponent } from './components/dialog-import-mermaid
     MapComponent,
     SliderPanelsComponent,
     ToolbarComponent,
+    LinksLayerComponent,
     DialogConnectionInfoComponent,
     DialogShareComponent,
     DialogImportMermaidComponent,

--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
@@ -1,0 +1,33 @@
+<svg class="links-svg">
+  <ng-container *ngFor="let link of links">
+    <g (mouseenter)="hovered = link.id" (mouseleave)="hovered = null">
+      <line
+        [attr.x1]="getPos(link.from).x"
+        [attr.y1]="getPos(link.from).y"
+        [attr.x2]="getPos(link.to).x"
+        [attr.y2]="getPos(link.to).y"
+        [ngClass]="{ hovered: hovered === link.id }"
+        pointer-events="stroke"
+      ></line>
+      <text
+        *ngIf="hovered === link.id"
+        [attr.x]="(getPos(link.from).x + getPos(link.to).x) / 2"
+        [attr.y]="(getPos(link.from).y + getPos(link.to).y) / 2"
+        class="delete"
+        (click)="delete(link.id)"
+      >
+        x
+      </text>
+    </g>
+  </ng-container>
+
+  <line
+    *ngIf="linkingFrom && cursor"
+    [attr.x1]="getPos(linkingFrom).x"
+    [attr.y1]="getPos(linkingFrom).y"
+    [attr.x2]="cursorPos.x"
+    [attr.y2]="cursorPos.y"
+    class="temp"
+    pointer-events="none"
+  ></line>
+</svg>

--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.scss
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.scss
@@ -1,0 +1,29 @@
+:host {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none; // let the map below handle normal clicks
+}
+
+line {
+  stroke: #666;
+  stroke-width: 2;
+}
+
+line.hovered {
+  stroke: #1976d2; // blue when hovered
+}
+
+line.temp {
+  stroke-dasharray: 4; // dashed temporary line
+}
+
+text.delete {
+  fill: #d32f2f;
+  font-size: 12px;
+  cursor: pointer;
+  pointer-events: all; // allow click
+  user-select: none;
+}

--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.ts
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.ts
@@ -1,0 +1,52 @@
+import { Component, Input, ElementRef } from '@angular/core';
+import { Link } from 'src/app/core/models/link.model';
+import { LinksService } from 'src/app/core/services/links/links.service';
+
+/**
+ * Renders SVG lines between nodes and handles hover/delete actions.
+ */
+@Component({
+  selector: 'teammapper-links-layer',
+  templateUrl: './links-layer.component.html',
+  styleUrls: ['./links-layer.component.scss'],
+  standalone: false,
+})
+export class LinksLayerComponent {
+  @Input() links: Link[] = []; // all saved links
+  @Input() linkingFrom: string | null = null; // node chosen first
+  @Input() cursor: { x: number; y: number } | null = null; // cursor while linking
+
+  public hovered: string | null = null; // id of hovered link
+
+  constructor(
+    private elementRef: ElementRef<HTMLElement>,
+    private linksService: LinksService
+  ) {}
+
+  /** Get the center position of a node on screen relative to map. */
+  public getPos(id: string): { x: number; y: number } {
+    const element = document.querySelector(
+      `[data-node-id='${id}'], [data-id='${id}'], #${id}`
+    ) as HTMLElement;
+    if (!element) return { x: 0, y: 0 };
+
+    const rect = element.getBoundingClientRect();
+    const hostRect = (this.elementRef.nativeElement.parentElement as HTMLElement).getBoundingClientRect();
+    return {
+      x: rect.left - hostRect.left + rect.width / 2,
+      y: rect.top - hostRect.top + rect.height / 2,
+    };
+  }
+
+  /** Position of the mouse relative to the map wrapper. */
+  public get cursorPos() {
+    if (!this.cursor) return { x: 0, y: 0 };
+    const hostRect = (this.elementRef.nativeElement.parentElement as HTMLElement).getBoundingClientRect();
+    return { x: this.cursor.x - hostRect.left, y: this.cursor.y - hostRect.top };
+  }
+
+  /** Remove link when user clicks the small x. */
+  public delete(id: string) {
+    this.linksService.removeLink(id);
+  }
+}

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
@@ -130,6 +130,14 @@
     mat-icon-button>
     <mat-icon>{{ hasHiddenNodes ? 'visibility_off' : 'visibility' }}</mat-icon>
   </button>
+  <button
+    (click)="linksService.toggleLinkMode()"
+    [title]="'Link mode'"
+    [disabled]="editDisabled"
+    [color]="(linksService.linkMode$ | async) ? 'accent' : 'primary'"
+    mat-icon-button>
+    <mat-icon>timeline</mat-icon>
+  </button>
 
   <div class="vertical-line">
     <div></div>

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.ts
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.ts
@@ -3,6 +3,7 @@ import { ExportNodeProperties } from '@mmp/map/types';
 import { TranslateService } from '@ngx-translate/core';
 import { DialogService } from 'src/app/core/services/dialog/dialog.service';
 import { MmpService } from 'src/app/core/services/mmp/mmp.service';
+import { LinksService } from 'src/app/core/services/links/links.service';
 import { environment } from 'src/environments/environment';
 
 @Component({
@@ -19,7 +20,8 @@ export class ToolbarComponent {
   constructor(
     private translationService: TranslateService,
     public mmpService: MmpService,
-    private dialogService: DialogService
+    private dialogService: DialogService,
+    public linksService: LinksService
   ) {}
 
   public async exportMap(format: string) {

--- a/teammapper-frontend/src/app/modules/application/pages/application/application.component.html
+++ b/teammapper-frontend/src/app/modules/application/pages/application/application.component.html
@@ -15,5 +15,12 @@
     [node]="node | async"
     [editDisabled]="editMode | async | inverseBool"></teammapper-toolbar>
 
-  <teammapper-map></teammapper-map>
+  <div class="map-wrapper">
+    <teammapper-map></teammapper-map>
+    <teammapper-links-layer
+      [links]="links"
+      [linkingFrom]="linkingFrom"
+      [cursor]="cursor"
+    ></teammapper-links-layer>
+  </div>
 </div>

--- a/teammapper-frontend/src/app/modules/application/pages/application/application.component.scss
+++ b/teammapper-frontend/src/app/modules/application/pages/application/application.component.scss
@@ -3,7 +3,12 @@ div.teammapper-application {
   display: flex;
   flex-direction: column;
 
-  teammapper-map {
+  .map-wrapper {
+    position: relative;
     flex: 1;
+  }
+
+  teammapper-map {
+    height: 100%;
   }
 }

--- a/teammapper-frontend/src/app/modules/application/pages/application/application.component.ts
+++ b/teammapper-frontend/src/app/modules/application/pages/application/application.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, HostListener } from '@angular/core';
 import { Subscription, Observable } from 'rxjs';
 import {
   ConnectionStatus,
@@ -12,6 +12,8 @@ import { ExportNodeProperties } from '@mmp/map/types';
 import { StorageService } from 'src/app/core/services/storage/storage.service';
 import { ServerMap } from 'src/app/core/services/map-sync/server-types';
 import { DialogService } from 'src/app/core/services/dialog/dialog.service';
+import { Link } from '../../../../core/models/link.model';
+import { LinksService } from '../../../../core/services/links/links.service';
 
 // Initialization process of a map:
 // 1) Render the wrapper element inside the map angular html component
@@ -27,6 +29,9 @@ import { DialogService } from 'src/app/core/services/dialog/dialog.service';
 export class ApplicationComponent implements OnInit, OnDestroy {
   public node: Observable<ExportNodeProperties>;
   public editMode: Observable<boolean>;
+  public links: Link[] = []; // stored links
+  public linkingFrom: string | null = null; // first selected node
+  public cursor: { x: number; y: number } | null = null; // cursor while linking
 
   private imageDropSubscription: Subscription;
   private connectionStatusSubscription: Subscription;
@@ -39,7 +44,8 @@ export class ApplicationComponent implements OnInit, OnDestroy {
     private dialogService: DialogService,
     private utilsService: UtilsService,
     private route: ActivatedRoute,
-    private router: Router
+    private router: Router,
+    private linksService: LinksService
   ) {}
 
   async ngOnInit() {
@@ -58,6 +64,16 @@ export class ApplicationComponent implements OnInit, OnDestroy {
           this.dialogService.openDisconnectDialog();
       });
     this.editMode = this.settingsService.getEditModeObservable();
+
+    // keep links updated
+    this.linksService.links$.subscribe(links => (this.links = links));
+    // reset selection when link mode is turned off
+    this.linksService.linkMode$.subscribe(active => {
+      if (!active) {
+        this.linkingFrom = null;
+        this.cursor = null;
+      }
+    });
   }
 
   ngOnDestroy() {
@@ -86,6 +102,9 @@ export class ApplicationComponent implements OnInit, OnDestroy {
       this.router.navigate(['/map']);
       return;
     }
+
+    // load saved links for this map
+    await this.linksService.setMapId(map.uuid);
   }
 
   private async loadAndPrepareWithMap(
@@ -119,5 +138,42 @@ export class ApplicationComponent implements OnInit, OnDestroy {
       });
       return privateServerMap.map;
     }
+  }
+
+  // Listen to clicks when link mode is active
+  @HostListener('document:click', ['$event'])
+  public onDocumentClick(event: MouseEvent) {
+    if (!this.linksService.isLinkModeActive()) return;
+    const nodeId = this.findNodeId(event.target as HTMLElement);
+    if (!nodeId) return;
+    if (!this.linkingFrom) {
+      this.linkingFrom = nodeId;
+    } else if (this.linkingFrom !== nodeId) {
+      this.linksService.addLink(this.linkingFrom, nodeId);
+      this.linkingFrom = null;
+      this.cursor = null;
+    }
+  }
+
+  // Track the cursor for the temporary line
+  @HostListener('document:mousemove', ['$event'])
+  public onDocumentMove(event: MouseEvent) {
+    if (this.linkingFrom) {
+      this.cursor = { x: event.clientX, y: event.clientY };
+    }
+  }
+
+  // Try to find a node id from the clicked element
+  private findNodeId(element: HTMLElement): string | null {
+    let el: HTMLElement | null = element;
+    while (el && el !== document.body) {
+      const id =
+        el.getAttribute('data-node-id') ||
+        el.getAttribute('data-id') ||
+        el.id;
+      if (id) return id;
+      el = el.parentElement;
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Summary
- allow toggling "Link mode" in editor toolbar
- draw and manage links between nodes with an SVG overlay
- store links per map using local storage

## Testing
- `npm test` *(fails: Cannot find module '@teammapper/mermaid-mindmap-parser')*

------
https://chatgpt.com/codex/tasks/task_e_68a3625ddabc832baa5948e0208a78f4