### PR TITLE
feat: add basic node linking

### DIFF
--- a/teammapper-frontend/src/app/core/services/links/links.service.ts
+++ b/teammapper-frontend/src/app/core/services/links/links.service.ts
@@ -41,23 +41,17 @@ export class LinksService {
   }
 
   /** Add a link from one node to another. */
-  public addLink(from: string, to: string): void {
-    if (from === to) return; // no self link
-
-    // sort ids so A-B and B-A are treated the same
-    if (from > to) [from, to] = [to, from];
-    const id = `${from}-${to}`;
-
+  public add(link: Link): void {
     const links = this.linksSubject.getValue();
-    if (links.find(l => l.id === id)) return; // avoid duplicates
+    if (links.find(l => l.id === link.id)) return; // avoid duplicates
 
-    const newLinks = [...links, { id, from, to }];
+    const newLinks = [...links, link];
     this.linksSubject.next(newLinks);
     this.save(newLinks);
   }
 
   /** Remove a link by its id. */
-  public removeLink(id: string): void {
+  public remove(id: string): void {
     const newLinks = this.linksSubject.getValue().filter(l => l.id !== id);
     this.linksSubject.next(newLinks);
     this.save(newLinks);

--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
@@ -22,9 +22,9 @@
   </ng-container>
 
   <line
-    *ngIf="linkingFrom && cursor"
-    [attr.x1]="getPos(linkingFrom).x"
-    [attr.y1]="getPos(linkingFrom).y"
+    *ngIf="selectedNodeId && cursor"
+    [attr.x1]="getPos(selectedNodeId).x"
+    [attr.y1]="getPos(selectedNodeId).y"
     [attr.x2]="cursorPos.x"
     [attr.y2]="cursorPos.y"
     class="temp"

--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.ts
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.ts
@@ -12,8 +12,8 @@ import { LinksService } from 'src/app/core/services/links/links.service';
   standalone: false,
 })
 export class LinksLayerComponent {
-  @Input() links: Link[] = []; // all saved links
-  @Input() linkingFrom: string | null = null; // node chosen first
+  public links: Link[] = []; // all saved links
+  @Input() selectedNodeId: string | null = null; // node chosen first
   @Input() cursor: { x: number; y: number } | null = null; // cursor while linking
 
   public hovered: string | null = null; // id of hovered link
@@ -21,7 +21,9 @@ export class LinksLayerComponent {
   constructor(
     private elementRef: ElementRef<HTMLElement>,
     private linksService: LinksService
-  ) {}
+  ) {
+    this.linksService.links$.subscribe(links => (this.links = links));
+  }
 
   /** Get the center position of a node on screen relative to map. */
   public getPos(id: string): { x: number; y: number } {
@@ -47,6 +49,6 @@ export class LinksLayerComponent {
 
   /** Remove link when user clicks the small x. */
   public delete(id: string) {
-    this.linksService.removeLink(id);
+    this.linksService.remove(id);
   }
 }

--- a/teammapper-frontend/src/app/modules/application/pages/application/application.component.html
+++ b/teammapper-frontend/src/app/modules/application/pages/application/application.component.html
@@ -18,8 +18,7 @@
   <div class="map-wrapper">
     <teammapper-map></teammapper-map>
     <teammapper-links-layer
-      [links]="links"
-      [linkingFrom]="linkingFrom"
+      [selectedNodeId]="selectedNodeId"
       [cursor]="cursor"
     ></teammapper-links-layer>
   </div>


### PR DESCRIPTION
## Summary
- support linking nodes with click and temporary cursor line
- persist links in storage and draw them with removable handles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a36857f5c0832bb5ca836a991d5b72