### PR TITLE
Ensure links layer SVG uses full component size

### DIFF
--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
@@ -1,4 +1,5 @@
-<svg class="links-svg">
+<svg class="links-svg" width="100%" height="100%">
+  <!-- area where link lines are drawn -->
   <ng-container *ngFor="let link of links">
     <g (mouseenter)="hovered = link.id" (mouseleave)="hovered = null">
       <line

--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.scss
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.scss
@@ -7,6 +7,12 @@
   pointer-events: none; // let the map below handle normal clicks
 }
 
+.links-svg {
+  width: 100%;
+  height: 100%;
+  // make the SVG fill the whole links layer
+}
+
 line {
   stroke: #666;
   stroke-width: 2;


### PR DESCRIPTION
## Summary
- expand links layer SVG to cover the full component
- reinforce SVG size with CSS rule so temporary and permanent link lines display correctly

## Testing
- `npm --prefix teammapper-frontend run build:dev`

------
https://chatgpt.com/codex/tasks/task_e_68a39e87c7cc832b941245cb671c10e8