### PR TITLE
style: layer map above link overlay

### DIFF
--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.scss
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.scss
@@ -5,6 +5,7 @@
   width: 100%;
   height: 100%;
   pointer-events: none; // let the map below handle normal clicks
+  z-index: 0; // place below the map
 }
 
 .links-svg {

--- a/teammapper-frontend/src/app/modules/application/pages/application/application.component.scss
+++ b/teammapper-frontend/src/app/modules/application/pages/application/application.component.scss
@@ -10,5 +10,7 @@ div.teammapper-application {
 
   teammapper-map {
     height: 100%;
+    position: relative; // stack above links layer
+    z-index: 1; // ensure map overlays links layer
   }
 }


### PR DESCRIPTION
## Summary
- place link overlay behind map by giving host a lower z-index
- ensure `teammapper-map` sits above link layer with z-index 1

## Testing
- `npm --prefix teammapper-frontend test -- --watch=false` *(fails: Cannot find module '@teammapper/mermaid-mindmap-parser')*
- `npm --prefix teammapper-frontend run lint` *(fails: lint errors present)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a56e6d98832b88e4f71c27eecf71