### PR TITLE
Trim cross-links to node edges

### DIFF
--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
@@ -1,22 +1,30 @@
 <svg class="links-svg" width="100%" height="100%">
   <!-- area where link lines are drawn -->
   <ng-container *ngFor="let link of links">
-    <g (mouseenter)="hovered = link.id" (mouseleave)="hovered = null">
+    <g
+      (mouseenter)="hovered = link.id"
+      (mouseleave)="hovered = null"
+      pointer-events="stroke"
+    >
       <line
-        [attr.x1]="getPos(link.fromNodeId).x"
-        [attr.y1]="getPos(link.fromNodeId).y"
-        [attr.x2]="getPos(link.toNodeId).x"
-        [attr.y2]="getPos(link.toNodeId).y"
+        [attr.x1]="getEdgePoint(link.fromNodeId, link.toNodeId).x"
+        [attr.y1]="getEdgePoint(link.fromNodeId, link.toNodeId).y"
+        [attr.x2]="getEdgePoint(link.toNodeId, link.fromNodeId).x"
+        [attr.y2]="getEdgePoint(link.toNodeId, link.fromNodeId).y"
         [ngClass]="{ hovered: hovered === link.id }"
-        pointer-events="stroke"
+        pointer-events="none"
       ></line>
       <text
         *ngIf="hovered === link.id"
         [attr.x]="
-          (getPos(link.fromNodeId).x + getPos(link.toNodeId).x) / 2
+          (getEdgePoint(link.fromNodeId, link.toNodeId).x +
+            getEdgePoint(link.toNodeId, link.fromNodeId).x) /
+          2
         "
         [attr.y]="
-          (getPos(link.fromNodeId).y + getPos(link.toNodeId).y) / 2
+          (getEdgePoint(link.fromNodeId, link.toNodeId).y +
+            getEdgePoint(link.toNodeId, link.fromNodeId).y) /
+          2
         "
         class="delete"
         (click)="delete(link.id)"
@@ -28,8 +36,8 @@
 
   <line
     *ngIf="selectedNodeId && cursor"
-    [attr.x1]="getPos(selectedNodeId).x"
-    [attr.y1]="getPos(selectedNodeId).y"
+    [attr.x1]="getEdgePoint(selectedNodeId, cursorPos).x"
+    [attr.y1]="getEdgePoint(selectedNodeId, cursorPos).y"
     [attr.x2]="cursorPos.x"
     [attr.y2]="cursorPos.y"
     class="temp"

--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.scss
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.scss
@@ -5,6 +5,7 @@
   width: 100%;
   height: 100%;
   pointer-events: none; // let the map below handle normal clicks
+  z-index: 0; // sit below nodes drawn with higher z-index
 }
 
 .links-svg {

--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.ts
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.ts
@@ -8,6 +8,8 @@ function getNodeEl(id: string): HTMLElement | null {
   return document.querySelector(sel) as HTMLElement | null;
 }
 
+const EDGE_PADDING = 8; // distance from node edge for link endpoints
+
 /**
  * Renders SVG lines between nodes and handles hover/delete actions.
  */
@@ -58,6 +60,59 @@ export class LinksLayerComponent {
     if (!this.cursor) return { x: 0, y: 0 };
     const hostRect = (this.elementRef.nativeElement.parentElement as HTMLElement).getBoundingClientRect();
     return { x: this.cursor.x - hostRect.left, y: this.cursor.y - hostRect.top };
+  }
+
+  /**
+   * Find point on edge of node's box toward another point.
+   * Returns ok=false if either node can't be found.
+   */
+  public getEdgePoint(
+    nodeId: string,
+    toward: string | { x: number; y: number }
+  ): { x: number; y: number; ok: boolean } {
+    const from = this.getPos(nodeId);
+    const el = getNodeEl(nodeId);
+    if (!el || !from.ok) return { x: 0, y: 0, ok: false };
+
+    const towardPos =
+      typeof toward === 'string' ? this.getPos(toward) : toward;
+
+    if (typeof toward === 'string' && !(towardPos as any).ok) {
+      return { x: 0, y: 0, ok: false };
+    }
+
+    const hostRect = (this.elementRef.nativeElement.parentElement as HTMLElement).getBoundingClientRect();
+    const rect = el.getBoundingClientRect();
+    const hostX = hostRect.left + window.scrollX;
+    const hostY = hostRect.top + window.scrollY;
+    const left = rect.left + window.scrollX - hostX;
+    const top = rect.top + window.scrollY - hostY;
+    const right = left + rect.width;
+    const bottom = top + rect.height;
+
+    const towardCoords =
+      typeof toward === 'string'
+        ? { x: (towardPos as any).x, y: (towardPos as any).y }
+        : towardPos;
+
+    const dx = towardCoords.x - from.x;
+    const dy = towardCoords.y - from.y;
+
+    let t = 1;
+    if (dx > 0) t = Math.min(t, (right - from.x) / dx);
+    if (dx < 0) t = Math.min(t, (left - from.x) / dx);
+    if (dy > 0) t = Math.min(t, (bottom - from.y) / dy);
+    if (dy < 0) t = Math.min(t, (top - from.y) / dy);
+
+    const edgeX = from.x + dx * t;
+    const edgeY = from.y + dy * t;
+    const len = Math.sqrt(dx * dx + dy * dy) || 1;
+
+    return {
+      x: edgeX + (dx / len) * EDGE_PADDING,
+      y: edgeY + (dy / len) * EDGE_PADDING,
+      ok: true,
+    };
   }
 
   /** Remove link when user clicks the small x. */


### PR DESCRIPTION
## Summary
- stop links from drawing through nodes by intersecting lines with node rectangles
- keep link lines non-blocking and below nodes

## Testing
- `npm test` *(fails: Cannot find module '@teammapper/mermaid-mindmap-parser')*


------
https://chatgpt.com/codex/tasks/task_e_68a4b7d53d00832b8956ee351c6ea57a