### PR TITLE
Render curved cross links behind nodes

### DIFF
--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
@@ -1,38 +1,31 @@
 <svg class="links-svg" width="100%" height="100%">
-  <!-- area where link lines are drawn -->
+  <!-- area where link paths are drawn -->
   <ng-container *ngFor="let link of links">
-    <g (mouseenter)="hovered = link.id" (mouseleave)="hovered = null">
-      <line
-        [attr.x1]="getPos(link.fromNodeId).x"
-        [attr.y1]="getPos(link.fromNodeId).y"
-        [attr.x2]="getPos(link.toNodeId).x"
-        [attr.y2]="getPos(link.toNodeId).y"
-        [ngClass]="{ hovered: hovered === link.id }"
-        pointer-events="stroke"
-      ></line>
-      <text
-        *ngIf="hovered === link.id"
-        [attr.x]="
-          (getPos(link.fromNodeId).x + getPos(link.toNodeId).x) / 2
-        "
-        [attr.y]="
-          (getPos(link.fromNodeId).y + getPos(link.toNodeId).y) / 2
-        "
-        class="delete"
-        (click)="delete(link.id)"
-      >
-        x
-      </text>
-    </g>
+    <ng-container *ngIf="getEdgePos(link.fromNodeId, link.toNodeId) as e">
+      <g (mouseenter)="hovered = link.id" (mouseleave)="hovered = null">
+        <path
+          [attr.d]="buildCurve(e.p1, e.p2)"
+          [ngClass]="{ hovered: hovered === link.id }"
+        ></path>
+        <text
+          *ngIf="hovered === link.id"
+          [attr.x]="(e.p1.x + e.p2.x) / 2"
+          [attr.y]="(e.p1.y + e.p2.y) / 2"
+          class="delete"
+          (click)="delete(link.id)"
+        >
+          x
+        </text>
+      </g>
+    </ng-container>
   </ng-container>
 
-  <line
-    *ngIf="selectedNodeId && cursor"
-    [attr.x1]="getPos(selectedNodeId).x"
-    [attr.y1]="getPos(selectedNodeId).y"
-    [attr.x2]="cursorPos.x"
-    [attr.y2]="cursorPos.y"
-    class="temp"
-    pointer-events="none"
-  ></line>
+  <ng-container *ngIf="selectedNodeId && cursor">
+    <ng-container *ngIf="edgeFromNodeToPoint(selectedNodeId, cursorPos) as start">
+      <path
+        [attr.d]="buildCurve(start, cursorPos)"
+        class="temp"
+      ></path>
+    </ng-container>
+  </ng-container>
 </svg>

--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.scss
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.scss
@@ -5,6 +5,7 @@
   width: 100%;
   height: 100%;
   pointer-events: none; // let the map below handle normal clicks
+  z-index: 0; // sit behind nodes
 }
 
 .links-svg {
@@ -13,17 +14,20 @@
   // make the SVG fill the whole links layer
 }
 
-line {
+path {
+  fill: none;
   stroke: #666;
   stroke-width: 2;
+  pointer-events: visibleStroke; // allow hover on stroke
 }
 
-line.hovered {
+path.hovered {
   stroke: #1976d2; // blue when hovered
 }
 
-line.temp {
-  stroke-dasharray: 4; // dashed temporary line
+path.temp {
+  stroke-dasharray: 4; // dashed temporary path
+  pointer-events: none; // ignore pointer events
 }
 
 text.delete {

--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.ts
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.ts
@@ -23,6 +23,7 @@ export class LinksLayerComponent {
   @Input() cursor: { x: number; y: number } | null = null; // cursor while linking
 
   public hovered: string | null = null; // id of hovered link
+  private readonly padding = 6; // small gap so lines avoid text
 
   constructor(
     private elementRef: ElementRef<HTMLElement>,
@@ -30,27 +31,106 @@ export class LinksLayerComponent {
   ) {
     // Update list of links and drop ones whose nodes are missing.
     this.linksService.links$.subscribe(links => {
+      // keep only links whose nodes still exist in the DOM
       this.links = links.filter(
-        l =>
-          this.getPos(l.fromNodeId).ok &&
-          this.getPos(l.toNodeId).ok
+        l => getNodeEl(l.fromNodeId) && getNodeEl(l.toNodeId)
       );
     });
   }
 
-  /** Get the center position of a node on screen relative to map. */
-  public getPos(id: string): { x: number; y: number; ok: boolean } {
-    const el = getNodeEl(id);
-    if (!el) return { x: 0, y: 0, ok: false };
+  /**
+   * Find two points where the line between nodes touches their edges.
+   * The rectangles are slightly inflated so the line stops before text.
+   */
+  public getEdgePos(
+    fromId: string,
+    toId: string
+  ): { p1: { x: number; y: number }; p2: { x: number; y: number } } | null {
+    const fromEl = getNodeEl(fromId);
+    const toEl = getNodeEl(toId);
+    if (!fromEl || !toEl) return null;
 
-    const rect = el.getBoundingClientRect();
     const hostRect = (this.elementRef.nativeElement.parentElement as HTMLElement).getBoundingClientRect();
-    // Compute center of the node and adjust to the SVG's coordinate space.
-    const x = rect.left + rect.width / 2 + window.scrollX;
-    const y = rect.top + rect.height / 2 + window.scrollY;
     const hostX = hostRect.left + window.scrollX;
     const hostY = hostRect.top + window.scrollY;
-    return { x: x - hostX, y: y - hostY, ok: true };
+
+    const pad = this.padding;
+    const makeRect = (el: HTMLElement) => {
+      const r = el.getBoundingClientRect();
+      return {
+        left: r.left + window.scrollX - hostX - pad,
+        right: r.right + window.scrollX - hostX + pad,
+        top: r.top + window.scrollY - hostY - pad,
+        bottom: r.bottom + window.scrollY - hostY + pad,
+      };
+    };
+
+    const r1 = makeRect(fromEl);
+    const r2 = makeRect(toEl);
+    const c1 = { x: (r1.left + r1.right) / 2, y: (r1.top + r1.bottom) / 2 };
+    const c2 = { x: (r2.left + r2.right) / 2, y: (r2.top + r2.bottom) / 2 };
+
+    const dx = c2.x - c1.x;
+    const dy = c2.y - c1.y;
+
+    const t1x = dx > 0 ? (r1.right - c1.x) / dx : (r1.left - c1.x) / dx;
+    const t1y = dy > 0 ? (r1.bottom - c1.y) / dy : (r1.top - c1.y) / dy;
+    const t1 = Math.min(t1x, t1y);
+    const p1 = { x: c1.x + dx * t1, y: c1.y + dy * t1 };
+
+    const dx2 = -dx;
+    const dy2 = -dy;
+    const t2x = dx2 > 0 ? (r2.right - c2.x) / dx2 : (r2.left - c2.x) / dx2;
+    const t2y = dy2 > 0 ? (r2.bottom - c2.y) / dy2 : (r2.top - c2.y) / dy2;
+    const t2 = Math.min(t2x, t2y);
+    const p2 = { x: c2.x + dx2 * t2, y: c2.y + dy2 * t2 };
+
+    return { p1, p2 };
+  }
+
+  /** Edge point from a node towards an arbitrary point (used for temp line). */
+  public edgeFromNodeToPoint(
+    id: string,
+    point: { x: number; y: number }
+  ): { x: number; y: number } | null {
+    const el = getNodeEl(id);
+    if (!el) return null;
+
+    const hostRect = (this.elementRef.nativeElement.parentElement as HTMLElement).getBoundingClientRect();
+    const hostX = hostRect.left + window.scrollX;
+    const hostY = hostRect.top + window.scrollY;
+    const r = el.getBoundingClientRect();
+    const rect = {
+      left: r.left + window.scrollX - hostX - this.padding,
+      right: r.right + window.scrollX - hostX + this.padding,
+      top: r.top + window.scrollY - hostY - this.padding,
+      bottom: r.bottom + window.scrollY - hostY + this.padding,
+    };
+    const c = { x: (rect.left + rect.right) / 2, y: (rect.top + rect.bottom) / 2 };
+    const dx = point.x - c.x;
+    const dy = point.y - c.y;
+    const tX = dx > 0 ? (rect.right - c.x) / dx : (rect.left - c.x) / dx;
+    const tY = dy > 0 ? (rect.bottom - c.y) / dy : (rect.top - c.y) / dy;
+    const t = Math.min(tX, tY);
+    return { x: c.x + dx * t, y: c.y + dy * t };
+  }
+
+  /** Build a smooth curve between two points. */
+  public buildCurve(
+    p1: { x: number; y: number },
+    p2: { x: number; y: number }
+  ): string {
+    const dx = p2.x - p1.x;
+    const dy = p2.y - p1.y;
+    const len = Math.sqrt(dx * dx + dy * dy) || 1;
+    const nx = -dy / len;
+    const ny = dx / len;
+    const offset = len * 0.2; // amount of curve
+    const cx1 = p1.x + dx / 3 + nx * offset;
+    const cy1 = p1.y + dy / 3 + ny * offset;
+    const cx2 = p1.x + (2 * dx) / 3 + nx * offset;
+    const cy2 = p1.y + (2 * dy) / 3 + ny * offset;
+    return `M ${p1.x} ${p1.y} C ${cx1} ${cy1}, ${cx2} ${cy2}, ${p2.x} ${p2.y}`;
   }
 
   /** Position of the mouse relative to the map wrapper. */

--- a/teammapper-frontend/src/app/modules/application/pages/application/application.component.scss
+++ b/teammapper-frontend/src/app/modules/application/pages/application/application.component.scss
@@ -10,5 +10,7 @@ div.teammapper-application {
 
   teammapper-map {
     height: 100%;
+    position: relative;
+    z-index: 1; // place nodes above links
   }
 }


### PR DESCRIPTION
## Summary
- compute link endpoints at node edges to avoid covering content
- draw cross links as curved paths styled like branches
- layer links SVG behind nodes via z-index adjustments

## Testing
- `npm test` *(fails: Cannot find module '@teammapper/mermaid-mindmap-parser')*

------
https://chatgpt.com/codex/tasks/task_e_68a4d691f9d8832b99d208a37811a37b