### PR TITLE
fix: render cross links behind nodes

### DIFF
--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.scss
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.scss
@@ -5,6 +5,7 @@
   width: 100%;
   height: 100%;
   pointer-events: none; // let the map below handle normal clicks
+  z-index: 1; // stay above map background but below nodes
 }
 
 .links-svg {

--- a/teammapper-frontend/src/app/modules/application/components/map/map.component.scss
+++ b/teammapper-frontend/src/app/modules/application/components/map/map.component.scss
@@ -1,3 +1,9 @@
 div.map {
   height: 100%;
 }
+
+:host ::ng-deep [data-node-id],
+:host ::ng-deep [data-id] {
+  position: relative; // ensure z-index works
+  z-index: 2; // keep nodes above link lines
+}


### PR DESCRIPTION
## Summary
- keep links layer above map background but below node elements
- apply z-index to node elements so cross links render underneath

## Testing
- `npm test -- --watch=false` *(fails: Cannot find module '@teammapper/mermaid-mindmap-parser')*
- `npm run lint` *(fails: prettier formatting issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a5eb296d6c832bb31df5667d9c0748