### PR TITLE
fix: layer links beneath nodes

### DIFF
--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.scss
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.scss
@@ -5,11 +5,13 @@
   width: 100%;
   height: 100%;
   pointer-events: none; // let the map below handle normal clicks
+  z-index: 0; // sit behind node layer
 }
 
 .links-svg {
   width: 100%;
   height: 100%;
+  pointer-events: none; // avoid blocking map events
   // make the SVG fill the whole links layer
 }
 

--- a/teammapper-frontend/src/app/modules/application/pages/application/application.component.scss
+++ b/teammapper-frontend/src/app/modules/application/pages/application/application.component.scss
@@ -6,9 +6,15 @@ div.teammapper-application {
   .map-wrapper {
     position: relative;
     flex: 1;
-  }
 
-  teammapper-map {
-    height: 100%;
+    teammapper-map {
+      position: relative;
+      z-index: 1; // place nodes above links
+      height: 100%;
+    }
+
+    teammapper-links-layer {
+      z-index: 0; // links stay underneath nodes
+    }
   }
 }


### PR DESCRIPTION
## Summary
- position links layer beneath map nodes using z-index
- ensure link SVG doesn't block map events

## Testing
- `npm test` *(fails: Cannot find module '@teammapper/mermaid-mindmap-parser')*
- `npm run lint` *(fails: prettier formatting errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5eb562ef0832ba822639d1edecd57