### PR TITLE
feat: allow styling cross links

### DIFF
--- a/teammapper-frontend/src/app/core/models/link.model.ts
+++ b/teammapper-frontend/src/app/core/models/link.model.ts
@@ -2,9 +2,17 @@
  * Basic link connecting two nodes on the map.
  * Each link is unique through its id.
  */
+/** Styling options for how a cross link is rendered on screen. */
+export interface LinkStyle {
+  color?: string; // line color
+  width?: number; // stroke width
+  dash?: string; // dash pattern "5 5" etc.
+  opacity?: number; // stroke opacity 0..1
+}
+
 export interface Link {
   id: string; // id of the link
   fromNodeId: string; // id of the first node
   toNodeId: string; // id of the second node
-  style?: any; // future style options
+  style?: LinkStyle; // optional styling
 }

--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
@@ -7,6 +7,10 @@
         [attr.y1]="getPos(link.fromNodeId).y"
         [attr.x2]="getPos(link.toNodeId).x"
         [attr.y2]="getPos(link.toNodeId).y"
+        [attr.stroke]="link.style?.color || '#666'"
+        [attr.stroke-width]="link.style?.width ?? 2"
+        [attr.stroke-dasharray]="link.style?.dash || null"
+        [attr.stroke-opacity]="link.style?.opacity ?? 1"
         [ngClass]="{ hovered: hovered === link.id }"
         pointer-events="stroke"
       ></line>

--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.scss
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.scss
@@ -7,15 +7,11 @@
   pointer-events: none; // let the map below handle normal clicks
 }
 
+
 .links-svg {
   width: 100%;
   height: 100%;
   // make the SVG fill the whole links layer
-}
-
-line {
-  stroke: #666;
-  stroke-width: 2;
 }
 
 line.hovered {
@@ -23,6 +19,8 @@ line.hovered {
 }
 
 line.temp {
+  stroke: #666; // default gray
+  stroke-width: 2; // default width
   stroke-dasharray: 4; // dashed temporary line
 }
 


### PR DESCRIPTION
## Summary
- allow cross links to declare style properties for color, width, dash, and opacity
- render link lines with customizable SVG attributes and keep defaults visible
- clean up link styles: hovered color via CSS, temp link keeps gray defaults

## Testing
- `npm run lint` *(fails: prettier/prettier and module resolution errors in unrelated files)*
- `npm test` *(fails: Cannot find module '@teammapper/mermaid-mindmap-parser')*


------
https://chatgpt.com/codex/tasks/task_e_68a74ff991e4832b97ab7deaf0b1c973