### PR TITLE
feat: draw cross links with branch path

### DIFF
--- a/teammapper-frontend/src/app/core/services/mmp/mmp.service.ts
+++ b/teammapper-frontend/src/app/core/services/mmp/mmp.service.ts
@@ -7,6 +7,7 @@ import { jsPDF } from 'jspdf';
 import { first } from 'rxjs/operators';
 import * as mmp from '@mmp/index';
 import MmpMap from '@mmp/map/map';
+import Node from '@mmp/map/models/node';
 import DOMPurify from 'dompurify';
 import {
   ExportHistory,
@@ -539,6 +540,27 @@ public importMap(json: string) {
    */
   public getCurrentMap(): MmpMap {
     return this.currentMap;
+  }
+
+  /**
+   * Compute a branch-like path between two nodes so cross-links can reuse
+   * the existing branch geometry. Returns an empty string if nodes are
+   * missing.
+   */
+  public branchPath(fromId: string, toId: string): string {
+    if (!this.currentMap) return '';
+
+    const from: Node = this.currentMap.nodes.getNode(fromId);
+    const to: Node = this.currentMap.nodes.getNode(toId);
+    if (!from || !to) return '';
+
+    const temp: Node = Object.assign(
+      Object.create(Object.getPrototypeOf(to)),
+      to
+    );
+    temp.parent = from;
+
+    return this.currentMap.draw.drawBranch(temp).toString();
   }
 
   /**

--- a/teammapper-frontend/src/app/core/services/mmp/mmp.service.ts
+++ b/teammapper-frontend/src/app/core/services/mmp/mmp.service.ts
@@ -564,6 +564,24 @@ public importMap(json: string) {
   }
 
   /**
+   * Return the map's current transform (translation & scale) so callers can
+   * render in the same coordinate space as mmp.
+   */
+  public mapTransform(): string {
+    if (!this.currentMap) return '';
+    return this.currentMap.dom.g.attr('transform') || '';
+  }
+
+  /**
+   * Retrieve node coordinates from the live map.
+   */
+  public nodeCoords(id: string): { x: number; y: number } | null {
+    if (!this.currentMap) return null;
+    const node: Node = this.currentMap.nodes.getNode(id);
+    return node ? { x: node.coordinates.x, y: node.coordinates.y } : null;
+  }
+
+  /**
    * Returns the current selected Node
    */
   public exportSelectedNode(): ExportNodeProperties {

--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
@@ -2,14 +2,13 @@
   <!-- area where link lines are drawn -->
   <ng-container *ngFor="let link of links">
     <g (mouseenter)="hovered = link.id" (mouseleave)="hovered = null">
-      <line
-        [attr.x1]="getPos(link.fromNodeId).x"
-        [attr.y1]="getPos(link.fromNodeId).y"
-        [attr.x2]="getPos(link.toNodeId).x"
-        [attr.y2]="getPos(link.toNodeId).y"
-        [ngClass]="{ hovered: hovered === link.id }"
+      <path
+        [attr.d]="mmpService.branchPath(link.fromNodeId, link.toNodeId)"
+        [attr.stroke]="hovered === link.id ? '#1976d2' : '#666'"
+        stroke-width="2"
+        fill="none"
         pointer-events="stroke"
-      ></line>
+      ></path>
       <text
         *ngIf="hovered === link.id"
         [attr.x]="

--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
@@ -1,29 +1,27 @@
 <svg class="links-svg" width="100%" height="100%">
   <!-- area where link lines are drawn -->
-  <ng-container *ngFor="let link of links">
-    <g (mouseenter)="hovered = link.id" (mouseleave)="hovered = null">
-      <path
-        [attr.d]="mmpService.branchPath(link.fromNodeId, link.toNodeId)"
-        [attr.stroke]="hovered === link.id ? '#1976d2' : '#666'"
-        stroke-width="2"
-        fill="none"
-        pointer-events="stroke"
-      ></path>
-      <text
-        *ngIf="hovered === link.id"
-        [attr.x]="
-          (getPos(link.fromNodeId).x + getPos(link.toNodeId).x) / 2
-        "
-        [attr.y]="
-          (getPos(link.fromNodeId).y + getPos(link.toNodeId).y) / 2
-        "
-        class="delete"
-        (click)="delete(link.id)"
-      >
-        x
-      </text>
-    </g>
-  </ng-container>
+  <g [attr.transform]="mmpService.mapTransform()">
+    <ng-container *ngFor="let link of links">
+      <g (mouseenter)="hovered = link.id" (mouseleave)="hovered = null">
+        <path
+          [attr.d]="mmpService.branchPath(link.fromNodeId, link.toNodeId)"
+          [attr.stroke]="hovered === link.id ? '#1976d2' : '#666'"
+          stroke-width="2"
+          fill="none"
+          pointer-events="stroke"
+        ></path>
+        <text
+          *ngIf="hovered === link.id"
+          [attr.x]="mid(link).x"
+          [attr.y]="mid(link).y"
+          class="delete"
+          (click)="delete(link.id)"
+        >
+          x
+        </text>
+      </g>
+    </ng-container>
+  </g>
 
   <line
     *ngIf="selectedNodeId && cursor"

--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.ts
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, ElementRef } from '@angular/core';
 import { Link } from 'src/app/core/models/link.model';
 import { LinksService } from 'src/app/core/services/links/links.service';
+import { MmpService } from 'src/app/core/services/mmp/mmp.service';
 
 // Find a node element using safe attribute lookups.
 function getNodeEl(id: string): HTMLElement | null {
@@ -26,7 +27,8 @@ export class LinksLayerComponent {
 
   constructor(
     private elementRef: ElementRef<HTMLElement>,
-    private linksService: LinksService
+    private linksService: LinksService,
+    public mmpService: MmpService
   ) {
     // Update list of links and drop ones whose nodes are missing.
     this.linksService.links$.subscribe(links => {

--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.ts
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.ts
@@ -62,6 +62,14 @@ export class LinksLayerComponent {
     return { x: this.cursor.x - hostRect.left, y: this.cursor.y - hostRect.top };
   }
 
+  /** Midpoint between two nodes in map coordinates. */
+  public mid(link: Link) {
+    const a = this.mmpService.nodeCoords(link.fromNodeId);
+    const b = this.mmpService.nodeCoords(link.toNodeId);
+    if (!a || !b) return { x: 0, y: 0 };
+    return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+  }
+
   /** Remove link when user clicks the small x. */
   public delete(id: string) {
     this.linksService.remove(id);


### PR DESCRIPTION
## Summary
- expose branchPath helper in MmpService to reuse drawBranch for cross-links
- render cross-links as curved <path> elements via mmpService

## Testing
- `npm --prefix teammapper-frontend run build:packages`
- `npm --prefix teammapper-frontend test`


------
https://chatgpt.com/codex/tasks/task_e_68a75ef82274832b83a6f10a20b84b84