### PR TITLE
feat: draw cross links with branch path

### DIFF
--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.html
@@ -1,30 +1,28 @@
 <svg class="links-svg" width="100%" height="100%">
   <!-- area where link lines are drawn -->
-  <ng-container *ngFor="let link of links">
-    <g (mouseenter)="hovered = link.id" (mouseleave)="hovered = null">
-      <line
-        [attr.x1]="getPos(link.fromNodeId).x"
-        [attr.y1]="getPos(link.fromNodeId).y"
-        [attr.x2]="getPos(link.toNodeId).x"
-        [attr.y2]="getPos(link.toNodeId).y"
-        [ngClass]="{ hovered: hovered === link.id }"
-        pointer-events="stroke"
-      ></line>
-      <text
-        *ngIf="hovered === link.id"
-        [attr.x]="
-          (getPos(link.fromNodeId).x + getPos(link.toNodeId).x) / 2
-        "
-        [attr.y]="
-          (getPos(link.fromNodeId).y + getPos(link.toNodeId).y) / 2
-        "
-        class="delete"
-        (click)="delete(link.id)"
-      >
-        x
-      </text>
-    </g>
-  </ng-container>
+  <g [attr.transform]="mmpService.mapTransform()">
+    <ng-container *ngFor="let link of links">
+      <g (mouseenter)="hovered = link.id" (mouseleave)="hovered = null">
+        <path
+          [attr.d]="mmpService.branchPath(link.fromNodeId, link.toNodeId)"
+          [attr.stroke]="hovered === link.id ? '#1976d2' : '#2c3e50'"
+          stroke-width="4"
+          stroke-linecap="round"
+          fill="none"
+          pointer-events="stroke"
+        ></path>
+        <text
+          *ngIf="hovered === link.id"
+          [attr.x]="mid(link).x"
+          [attr.y]="mid(link).y"
+          class="delete"
+          (click)="delete(link.id)"
+        >
+          x
+        </text>
+      </g>
+    </ng-container>
+  </g>
 
   <line
     *ngIf="selectedNodeId && cursor"

--- a/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.ts
+++ b/teammapper-frontend/src/app/modules/application/components/links-layer/links-layer.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, ElementRef } from '@angular/core';
 import { Link } from 'src/app/core/models/link.model';
 import { LinksService } from 'src/app/core/services/links/links.service';
+import { MmpService } from 'src/app/core/services/mmp/mmp.service';
 
 // Find a node element using safe attribute lookups.
 function getNodeEl(id: string): HTMLElement | null {
@@ -26,7 +27,8 @@ export class LinksLayerComponent {
 
   constructor(
     private elementRef: ElementRef<HTMLElement>,
-    private linksService: LinksService
+    private linksService: LinksService,
+    public mmpService: MmpService
   ) {
     // Update list of links and drop ones whose nodes are missing.
     this.linksService.links$.subscribe(links => {
@@ -58,6 +60,14 @@ export class LinksLayerComponent {
     if (!this.cursor) return { x: 0, y: 0 };
     const hostRect = (this.elementRef.nativeElement.parentElement as HTMLElement).getBoundingClientRect();
     return { x: this.cursor.x - hostRect.left, y: this.cursor.y - hostRect.top };
+  }
+
+  /** Midpoint between two nodes in map coordinates. */
+  public mid(link: Link) {
+    const a = this.mmpService.nodeCoords(link.fromNodeId);
+    const b = this.mmpService.nodeCoords(link.toNodeId);
+    if (!a || !b) return { x: 0, y: 0 };
+    return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
   }
 
   /** Remove link when user clicks the small x. */


### PR DESCRIPTION
## Summary
- replace branchPath with a trimmed cubic path so cross-links start and end outside nodes
- stroke cross-links with a neutral color and rounded caps for a cleaner look

## Testing
- `npm --prefix teammapper-frontend run build:packages`
- `npm --prefix teammapper-frontend test`

## Rollback
- `git revert cae9fc1`


------
https://chatgpt.com/codex/tasks/task_e_68a75ef82274832b83a6f10a20b84b84