### PR TITLE
feat: add basic circle drawing

### DIFF
--- a/teammapper-frontend/src/app/core/models/shape.model.ts
+++ b/teammapper-frontend/src/app/core/models/shape.model.ts
@@ -7,5 +7,5 @@ export interface Shape {
   x: number; // center x in map coordinates
   y: number; // center y in map coordinates
   radius: number; // circle radius in pixels
-  color: string; // fill color
+  color: string; // border color
 }

--- a/teammapper-frontend/src/app/core/models/shape.model.ts
+++ b/teammapper-frontend/src/app/core/models/shape.model.ts
@@ -1,0 +1,11 @@
+/**
+ * Simple shape on the map (currently only circles).
+ */
+export interface Shape {
+  id: string; // unique id
+  type: 'circle'; // future shape types
+  x: number; // center x in map coordinates
+  y: number; // center y in map coordinates
+  radius: number; // circle radius in pixels
+  color: string; // fill color
+}

--- a/teammapper-frontend/src/app/core/services/mmp/mmp.service.ts
+++ b/teammapper-frontend/src/app/core/services/mmp/mmp.service.ts
@@ -20,6 +20,7 @@ import { COLORS, EMPTY_IMAGE_DATA } from './mmp-utils';
 import { CachedMapOptions } from 'src/app/shared/models/cached-map.model';
 import { validate as uuidValidate } from 'uuid';
 import { LinksService } from '../links/links.service';
+import { ShapesService } from '../shapes/shapes.service';
 
 /**
  * Mmp wrapper service with mmp and other functions.
@@ -39,7 +40,8 @@ export class MmpService implements OnDestroy {
     public settingsService: SettingsService,
     public utilsService: UtilsService,
     public toastrService: ToastrService,
-    private linksService: LinksService
+    private linksService: LinksService,
+    private shapesService: ShapesService
   ) {
     this.additionalOptions = null;
     this.branchColors = COLORS;
@@ -489,13 +491,20 @@ public importMap(json: string) {
     // Old format: nodes only
     this.new(parsed);
     // Emit AFTER nodes mount so the layer sees them
-    setTimeout(() => this.linksService.setAll([]), 0);
+    setTimeout(() => {
+      this.linksService.setAll([]);
+      this.shapesService.setAll([]);
+    }, 0);
   } else {
     const nodes = parsed.nodes || [];
     const links = Array.isArray(parsed.crossLinks) ? parsed.crossLinks : [];
+    const shapes = Array.isArray(parsed.shapes) ? parsed.shapes : [];
     this.new(nodes);
     // Emit AFTER nodes mount so the layer sees them
-    setTimeout(() => this.linksService.setAll(links), 0);
+    setTimeout(() => {
+      this.linksService.setAll(links);
+      this.shapesService.setAll(shapes);
+    }, 0);
   }
 }
 
@@ -730,6 +739,7 @@ public importMap(json: string) {
       version: 2,
       nodes: this.exportAsJSON(),
       crossLinks: this.linksService.getAll(),
+      shapes: this.shapesService.getAll(),
     };
     const json = JSON.stringify(data);
     const uri = `data:text/json;charset=utf-8,${encodeURIComponent(json)}`;

--- a/teammapper-frontend/src/app/core/services/shapes/shapes.service.ts
+++ b/teammapper-frontend/src/app/core/services/shapes/shapes.service.ts
@@ -1,0 +1,155 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { nanoid } from 'nanoid/non-secure';
+import { Shape } from '../../models/shape.model';
+import { StorageService } from '../storage/storage.service';
+
+/**
+ * Manages drawable shapes on top of the map and keeps them in local storage.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class ShapesService {
+  private mapId: string;
+  private shapesSubject = new BehaviorSubject<Shape[]>([]);
+  public shapes$: Observable<Shape[]> = this.shapesSubject.asObservable();
+
+  private selectedSubject = new BehaviorSubject<string | null>(null);
+  public selected$ = this.selectedSubject.asObservable();
+
+  private drawModeSubject = new BehaviorSubject<boolean>(false);
+  public drawMode$ = this.drawModeSubject.asObservable();
+
+  private history: Shape[][] = [];
+  private redoStack: Shape[][] = [];
+
+  constructor(private storage: StorageService) {}
+
+  /** Load shapes for the current map id. */
+  public async setMapId(id: string): Promise<void> {
+    this.mapId = id;
+    const stored = (await this.storage.get(this.storageKey())) as Shape[];
+    const shapes = stored || [];
+    this.shapesSubject.next(this.clone(shapes));
+    this.history = [this.clone(shapes)];
+    this.redoStack = [];
+  }
+
+  /** Return all shapes. */
+  public getAll(): Shape[] {
+    return this.shapesSubject.getValue();
+  }
+
+  /** Replace all shapes with a new set. */
+  public setAll(shapes: Shape[]): void {
+    this.setShapes(this.clone(shapes), true);
+  }
+
+  /** Add a new circle at position. */
+  public add(shape: Partial<Shape>): Shape {
+    const newShape: Shape = {
+      id: shape.id || `sh_${nanoid()}`,
+      type: 'circle',
+      x: shape.x ?? 0,
+      y: shape.y ?? 0,
+      radius: shape.radius ?? 40,
+      color: shape.color ?? '#1976d2',
+    };
+    const shapes = [...this.getAll(), newShape];
+    this.setShapes(shapes, true);
+    this.select(newShape.id);
+    return newShape;
+  }
+
+  /** Update properties of a shape without recording history. */
+  public update(id: string, patch: Partial<Shape>): void {
+    const shapes = this.getAll().map(s =>
+      s.id === id ? { ...s, ...patch } : s
+    );
+    this.setShapes(shapes, false);
+  }
+
+  /** Commit current shapes to history after updates (e.g., resize). */
+  public commit(): void {
+    this.history.push(this.clone(this.getAll()));
+    this.redoStack = [];
+    this.save();
+  }
+
+  /** Remove a shape by id. */
+  public remove(id: string): void {
+    const shapes = this.getAll().filter(s => s.id !== id);
+    this.setShapes(shapes, true);
+    if (this.selectedSubject.getValue() === id) {
+      this.selectedSubject.next(null);
+    }
+  }
+
+  /** Undo last change. */
+  public undo(): void {
+    if (this.history.length > 1) {
+      const last = this.history.pop();
+      this.redoStack.push(last);
+      const prev = this.clone(this.history[this.history.length - 1]);
+      this.shapesSubject.next(prev);
+      this.save();
+    }
+  }
+
+  /** Redo change. */
+  public redo(): void {
+    if (this.redoStack.length > 0) {
+      const next = this.redoStack.pop();
+      this.history.push(this.clone(next));
+      this.shapesSubject.next(this.clone(next));
+      this.save();
+    }
+  }
+
+  /** Selection helpers */
+  public select(id: string | null): void {
+    this.selectedSubject.next(id);
+  }
+
+  public getSelected(): string | null {
+    return this.selectedSubject.getValue();
+  }
+
+  public clearSelection(): void {
+    this.selectedSubject.next(null);
+  }
+
+  /** Toggle draw mode */
+  public toggleDrawMode(): void {
+    const current = this.drawModeSubject.getValue();
+    this.drawModeSubject.next(!current);
+  }
+
+  public isDrawModeActive(): boolean {
+    return this.drawModeSubject.getValue();
+  }
+
+  /** Save shapes to storage */
+  private save(shapes: Shape[] = this.getAll()): void {
+    if (!this.mapId) return;
+    this.storage.set(this.storageKey(), shapes);
+  }
+
+  private setShapes(shapes: Shape[], recordHistory: boolean): void {
+    this.shapesSubject.next(this.clone(shapes));
+    this.save(shapes);
+    if (recordHistory) {
+      this.history.push(this.clone(shapes));
+      this.redoStack = [];
+    }
+  }
+
+  private storageKey(): string {
+    return `shapes-${this.mapId}`;
+  }
+
+  private clone(shapes: Shape[]): Shape[] {
+    return JSON.parse(JSON.stringify(shapes));
+  }
+}

--- a/teammapper-frontend/src/app/core/services/shapes/shapes.service.ts
+++ b/teammapper-frontend/src/app/core/services/shapes/shapes.service.ts
@@ -123,7 +123,11 @@ export class ShapesService {
   /** Toggle draw mode */
   public toggleDrawMode(): void {
     const current = this.drawModeSubject.getValue();
-    this.drawModeSubject.next(!current);
+    const next = !current;
+    this.drawModeSubject.next(next);
+    if (!next) {
+      this.clearSelection();
+    }
   }
 
   public isDrawModeActive(): boolean {

--- a/teammapper-frontend/src/app/modules/application/application.module.ts
+++ b/teammapper-frontend/src/app/modules/application/application.module.ts
@@ -21,6 +21,7 @@ import { MatDialogModule } from '@angular/material/dialog';
 import { MatGridListModule } from '@angular/material/grid-list';
 import { DialogImportMermaidComponent } from './components/dialog-import-mermaid/dialog-import-mermaid.component';
 import { LinksLayerComponent } from './components/links-layer/links-layer.component';
+import { ShapesLayerComponent } from './components/shapes-layer/shapes-layer.component';
 
 @NgModule({
   imports: [
@@ -43,6 +44,7 @@ import { LinksLayerComponent } from './components/links-layer/links-layer.compon
     SliderPanelsComponent,
     ToolbarComponent,
     LinksLayerComponent,
+    ShapesLayerComponent,
     DialogConnectionInfoComponent,
     DialogShareComponent,
     DialogImportMermaidComponent,

--- a/teammapper-frontend/src/app/modules/application/components/shapes-layer/shapes-layer.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/shapes-layer/shapes-layer.component.html
@@ -6,12 +6,26 @@
   [style.top.px]="shape.y - shape.radius"
   [style.width.px]="shape.radius * 2"
   [style.height.px]="shape.radius * 2"
-  [style.background]="shape.color"
+  [style.border-color]="shape.color"
   (mousedown)="selectShape($event, shape.id)"
 >
+  <button
+    *ngIf="shape.id === selectedId"
+    class="delete-button"
+    (mousedown)="deleteShape($event, shape.id)"
+  >
+    ×
+  </button>
+  <div
+    *ngIf="shape.id === selectedId"
+    class="move-handle"
+    [style.border-color]="shape.color"
+    (mousedown)="startMove($event, shape)"
+  ></div>
   <div
     *ngIf="shape.id === selectedId"
     class="resize-handle"
+    [style.background]="shape.color"
     (mousedown)="startResize($event, shape)"
   ></div>
 </div>

--- a/teammapper-frontend/src/app/modules/application/components/shapes-layer/shapes-layer.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/shapes-layer/shapes-layer.component.html
@@ -1,0 +1,17 @@
+<div
+  *ngFor="let shape of shapes"
+  class="shape"
+  [class.selected]="shape.id === selectedId"
+  [style.left.px]="shape.x - shape.radius"
+  [style.top.px]="shape.y - shape.radius"
+  [style.width.px]="shape.radius * 2"
+  [style.height.px]="shape.radius * 2"
+  [style.background]="shape.color"
+  (mousedown)="selectShape($event, shape.id)"
+>
+  <div
+    *ngIf="shape.id === selectedId"
+    class="resize-handle"
+    (mousedown)="startResize($event, shape)"
+  ></div>
+</div>

--- a/teammapper-frontend/src/app/modules/application/components/shapes-layer/shapes-layer.component.scss
+++ b/teammapper-frontend/src/app/modules/application/components/shapes-layer/shapes-layer.component.scss
@@ -1,0 +1,33 @@
+:host {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none; // allow map interaction when not drawing
+}
+
+:host.drawing {
+  pointer-events: all;
+}
+
+.shape {
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: all;
+  border: 2px solid transparent;
+}
+
+.shape.selected {
+  border-color: #1976d2;
+}
+
+.resize-handle {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  right: -4px;
+  bottom: -4px;
+  background: #1976d2;
+  cursor: se-resize;
+}

--- a/teammapper-frontend/src/app/modules/application/components/shapes-layer/shapes-layer.component.scss
+++ b/teammapper-frontend/src/app/modules/application/components/shapes-layer/shapes-layer.component.scss
@@ -14,10 +14,14 @@
 .shape {
   position: absolute;
   border-radius: 50%;
-  pointer-events: all;
+  pointer-events: none;
   border: 2px solid;
   background: transparent;
   box-sizing: border-box;
+}
+
+:host.drawing .shape {
+  pointer-events: all;
 }
 
 .shape.selected {

--- a/teammapper-frontend/src/app/modules/application/components/shapes-layer/shapes-layer.component.scss
+++ b/teammapper-frontend/src/app/modules/application/components/shapes-layer/shapes-layer.component.scss
@@ -15,11 +15,13 @@
   position: absolute;
   border-radius: 50%;
   pointer-events: all;
-  border: 2px solid transparent;
+  border: 2px solid;
+  background: transparent;
+  box-sizing: border-box;
 }
 
 .shape.selected {
-  border-color: #1976d2;
+  outline: 2px solid #1976d2;
 }
 
 .resize-handle {
@@ -30,4 +32,35 @@
   bottom: -4px;
   background: #1976d2;
   cursor: se-resize;
+}
+
+.move-handle {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  left: -4px;
+  top: -4px;
+  border: 2px solid #1976d2;
+  border-radius: 50%;
+  background: #fff;
+  cursor: move;
+}
+
+.delete-button {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  top: -8px;
+  right: -8px;
+  background: #f44336;
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 16px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/teammapper-frontend/src/app/modules/application/components/shapes-layer/shapes-layer.component.ts
+++ b/teammapper-frontend/src/app/modules/application/components/shapes-layer/shapes-layer.component.ts
@@ -27,6 +27,12 @@ export class ShapesLayerComponent {
   private startX = 0;
   private startY = 0;
 
+  private movingId: string | null = null;
+  private moveStartX = 0;
+  private moveStartY = 0;
+  private shapeStartX = 0;
+  private shapeStartY = 0;
+
   constructor(
     private elementRef: ElementRef<HTMLElement>,
     public shapesService: ShapesService
@@ -85,4 +91,41 @@ export class ShapesLayerComponent {
     window.removeEventListener('mousemove', this.onResize);
     window.removeEventListener('mouseup', this.stopResize);
   };
+
+  /** Start moving the shape */
+  public startMove(event: MouseEvent, shape: Shape) {
+    event.stopPropagation();
+    this.movingId = shape.id;
+    this.moveStartX = event.clientX;
+    this.moveStartY = event.clientY;
+    this.shapeStartX = shape.x;
+    this.shapeStartY = shape.y;
+    window.addEventListener('mousemove', this.onMove);
+    window.addEventListener('mouseup', this.stopMove);
+  }
+
+  private onMove = (event: MouseEvent) => {
+    if (!this.movingId) return;
+    const dx = event.clientX - this.moveStartX;
+    const dy = event.clientY - this.moveStartY;
+    this.shapesService.update(this.movingId, {
+      x: this.shapeStartX + dx,
+      y: this.shapeStartY + dy,
+    });
+  };
+
+  private stopMove = () => {
+    if (this.movingId) {
+      this.shapesService.commit();
+    }
+    this.movingId = null;
+    window.removeEventListener('mousemove', this.onMove);
+    window.removeEventListener('mouseup', this.stopMove);
+  };
+
+  /** Delete shape via handle */
+  public deleteShape(event: MouseEvent, id: string) {
+    event.stopPropagation();
+    this.shapesService.remove(id);
+  }
 }

--- a/teammapper-frontend/src/app/modules/application/components/shapes-layer/shapes-layer.component.ts
+++ b/teammapper-frontend/src/app/modules/application/components/shapes-layer/shapes-layer.component.ts
@@ -1,0 +1,88 @@
+import {
+  Component,
+  ElementRef,
+  HostBinding,
+  HostListener,
+} from '@angular/core';
+import { nanoid } from 'nanoid/non-secure';
+import { Shape } from 'src/app/core/models/shape.model';
+import { ShapesService } from 'src/app/core/services/shapes/shapes.service';
+
+/**
+ * Renders and edits simple shapes (circles) on top of the map.
+ */
+@Component({
+  selector: 'teammapper-shapes-layer',
+  templateUrl: './shapes-layer.component.html',
+  styleUrls: ['./shapes-layer.component.scss'],
+  standalone: false,
+})
+export class ShapesLayerComponent {
+  public shapes: Shape[] = [];
+  public selectedId: string | null = null;
+  public drawMode = false;
+
+  private resizingId: string | null = null;
+  private startRadius = 0;
+  private startX = 0;
+  private startY = 0;
+
+  constructor(
+    private elementRef: ElementRef<HTMLElement>,
+    public shapesService: ShapesService
+  ) {
+    this.shapesService.shapes$.subscribe(s => (this.shapes = s));
+    this.shapesService.selected$.subscribe(id => (this.selectedId = id));
+    this.shapesService.drawMode$.subscribe(mode => (this.drawMode = mode));
+  }
+
+  @HostBinding('class.drawing') get drawing() {
+    return this.drawMode;
+  }
+
+  /** Handle clicks on empty layer to create a new circle. */
+  @HostListener('click', ['$event'])
+  onHostClick(event: MouseEvent) {
+    if (!this.drawMode) return;
+    if (event.target !== this.elementRef.nativeElement) return;
+    const rect = this.elementRef.nativeElement.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    this.shapesService.add({ id: `sh_${nanoid()}`, x, y });
+  }
+
+  /** Select a shape */
+  public selectShape(event: MouseEvent, id: string) {
+    event.stopPropagation();
+    this.shapesService.select(id);
+  }
+
+  /** Start resizing using the little handle */
+  public startResize(event: MouseEvent, shape: Shape) {
+    event.stopPropagation();
+    this.resizingId = shape.id;
+    this.startRadius = shape.radius;
+    this.startX = event.clientX;
+    this.startY = event.clientY;
+    window.addEventListener('mousemove', this.onResize);
+    window.addEventListener('mouseup', this.stopResize);
+  }
+
+  private onResize = (event: MouseEvent) => {
+    if (!this.resizingId) return;
+    const dx = event.clientX - this.startX;
+    const dy = event.clientY - this.startY;
+    const delta = Math.max(dx, dy);
+    const newRadius = Math.max(10, this.startRadius + delta);
+    this.shapesService.update(this.resizingId, { radius: newRadius });
+  };
+
+  private stopResize = () => {
+    if (this.resizingId) {
+      this.shapesService.commit();
+    }
+    this.resizingId = null;
+    window.removeEventListener('mousemove', this.onResize);
+    window.removeEventListener('mouseup', this.stopResize);
+  };
+}

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
@@ -86,6 +86,14 @@
     <mat-icon>share</mat-icon>
   </button>
 
+  <button
+    (click)="toggleShapeMode()"
+    title="Add circle"
+    color="primary"
+    mat-icon-button>
+    <mat-icon>panorama_fish_eye</mat-icon>
+  </button>
+
   <div class="vertical-line">
     <div></div>
   </div>
@@ -144,7 +152,7 @@
   </div>
 
   <button
-    (click)="mmpService.undo()"
+    (click)="undo()"
     [title]="'TOOLTIPS.UNDO_MAP' | translate"
     [disabled]="editDisabled || !canUndoRedo"
     color="primary"
@@ -153,7 +161,7 @@
   </button>
 
   <button
-    (click)="mmpService.redo()"
+    (click)="redo()"
     [title]="'TOOLTIPS.REDO_MAP' | translate"
     [disabled]="editDisabled || !canUndoRedo"
     color="primary"

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
@@ -89,7 +89,7 @@
   <button
     (click)="toggleShapeMode()"
     title="Add circle"
-    color="primary"
+    [color]="(shapesService.drawMode$ | async) ? 'accent' : 'primary'"
     mat-icon-button>
     <mat-icon>panorama_fish_eye</mat-icon>
   </button>

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.spec.ts
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.spec.ts
@@ -6,6 +6,7 @@ import { ToolbarComponent } from './toolbar.component';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
 import { ExportNodeProperties } from '@mmp/map/types';
 import { Font } from 'mmp/src/map/models/node';
 import { of } from 'rxjs';
@@ -44,6 +45,7 @@ describe('ToolbarComponent', () => {
       toggleDrawMode: jest.fn(),
       undo: jest.fn(),
       redo: jest.fn(),
+      drawMode$: of(false),
     } as unknown as jest.Mocked<ShapesService>;
 
     mockTranslateService = {
@@ -62,6 +64,7 @@ describe('ToolbarComponent', () => {
         MatToolbarModule,
         TranslateModule.forRoot(),
         MatIconModule,
+        MatButtonModule,
       ],
       providers: [
         { provide: MmpService, useValue: mockMmpService },

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.spec.ts
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.spec.ts
@@ -9,6 +9,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { ExportNodeProperties } from '@mmp/map/types';
 import { Font } from 'mmp/src/map/models/node';
 import { of } from 'rxjs';
+import { ShapesService } from 'src/app/core/services/shapes/shapes.service';
 
 describe('ToolbarComponent', () => {
   let component: ToolbarComponent;
@@ -16,6 +17,7 @@ describe('ToolbarComponent', () => {
   let mockMmpService: jest.Mocked<MmpService>;
   let mockDialogService: jest.Mocked<DialogService>;
   let mockTranslateService: jest.Mocked<TranslateService>;
+  let mockShapesService: jest.Mocked<ShapesService>;
 
   beforeEach(async () => {
     mockMmpService = {
@@ -38,6 +40,12 @@ describe('ToolbarComponent', () => {
       openPictogramDialog: jest.fn(),
     } as unknown as jest.Mocked<DialogService>;
 
+    mockShapesService = {
+      toggleDrawMode: jest.fn(),
+      undo: jest.fn(),
+      redo: jest.fn(),
+    } as unknown as jest.Mocked<ShapesService>;
+
     mockTranslateService = {
       use: jest.fn().mockReturnValue(Promise.resolve('en')),
       get: jest.fn().mockReturnValue(of('translated value')),
@@ -59,6 +67,7 @@ describe('ToolbarComponent', () => {
         { provide: MmpService, useValue: mockMmpService },
         { provide: DialogService, useValue: mockDialogService },
         { provide: TranslateService, useValue: mockTranslateService },
+        { provide: ShapesService, useValue: mockShapesService },
       ],
     }).compileComponents();
 

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.ts
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.ts
@@ -5,6 +5,7 @@ import { DialogService } from 'src/app/core/services/dialog/dialog.service';
 import { MmpService } from 'src/app/core/services/mmp/mmp.service';
 import { LinksService } from 'src/app/core/services/links/links.service';
 import { environment } from 'src/environments/environment';
+import { ShapesService } from 'src/app/core/services/shapes/shapes.service';
 
 @Component({
   selector: 'teammapper-toolbar',
@@ -21,7 +22,8 @@ export class ToolbarComponent {
     private translationService: TranslateService,
     public mmpService: MmpService,
     private dialogService: DialogService,
-    public linksService: LinksService
+    public linksService: LinksService,
+    private shapesService: ShapesService
   ) {}
 
   public async exportMap(format: string) {
@@ -87,8 +89,22 @@ export class ToolbarComponent {
     this.mmpService.addNode({ detached: true, name: '' });
   }
 
+  public toggleShapeMode() {
+    this.shapesService.toggleDrawMode();
+  }
+
   public removeLink() {
     this.mmpService.removeNodeLink();
+  }
+
+  public undo() {
+    this.shapesService.undo();
+    this.mmpService.undo();
+  }
+
+  public redo() {
+    this.shapesService.redo();
+    this.mmpService.redo();
   }
 
   public toogleNodeFontWeight() {

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.ts
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.ts
@@ -23,7 +23,7 @@ export class ToolbarComponent {
     public mmpService: MmpService,
     private dialogService: DialogService,
     public linksService: LinksService,
-    private shapesService: ShapesService
+    public shapesService: ShapesService
   ) {}
 
   public async exportMap(format: string) {

--- a/teammapper-frontend/src/app/modules/application/pages/application/application.component.html
+++ b/teammapper-frontend/src/app/modules/application/pages/application/application.component.html
@@ -21,5 +21,6 @@
       [selectedNodeId]="selectedNodeId"
       [cursor]="cursor"
     ></teammapper-links-layer>
+    <teammapper-shapes-layer></teammapper-shapes-layer>
   </div>
 </div>

--- a/teammapper-frontend/src/app/modules/application/pages/application/application.component.ts
+++ b/teammapper-frontend/src/app/modules/application/pages/application/application.component.ts
@@ -14,6 +14,7 @@ import { ServerMap } from 'src/app/core/services/map-sync/server-types';
 import { DialogService } from 'src/app/core/services/dialog/dialog.service';
 import { Link } from '../../../../core/models/link.model';
 import { LinksService } from '../../../../core/services/links/links.service';
+import { ShapesService } from 'src/app/core/services/shapes/shapes.service';
 
 // Find a node element on the page using stable attributes.
 function getNodeEl(id: string): HTMLElement | null {
@@ -47,7 +48,8 @@ export class ApplicationComponent implements OnInit, OnDestroy {
     private utilsService: UtilsService,
     private route: ActivatedRoute,
     private router: Router,
-    private linksService: LinksService
+    private linksService: LinksService,
+    private shapesService: ShapesService
   ) {}
 
   async ngOnInit() {
@@ -100,6 +102,7 @@ export class ApplicationComponent implements OnInit, OnDestroy {
     }
 
     await this.linksService.setMapId(map.uuid);
+    await this.shapesService.setMapId(map.uuid);
   }
 
   private async loadAndPrepareWithMap(
@@ -137,6 +140,7 @@ export class ApplicationComponent implements OnInit, OnDestroy {
 
   @HostListener('document:click', ['$event'])
   public onDocumentClick(event: MouseEvent) {
+    if (this.shapesService.isDrawModeActive()) return;
     if (!this.linksService.isLinkModeActive()) return;
 
     const nodeId = this.findNodeId(event.target as HTMLElement);
@@ -178,6 +182,14 @@ export class ApplicationComponent implements OnInit, OnDestroy {
   public onKeyDown(event: KeyboardEvent) {
     if (event.key === 'Escape') {
       this.clearSelection();
+      this.shapesService.clearSelection();
+    }
+    if (event.key === 'Delete') {
+      const sel = this.shapesService.getSelected();
+      if (sel) {
+        this.shapesService.remove(sel);
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- allow users to draw, resize and remove circles over the map
- persist shapes via new ShapesService and include them in JSON import/export
- expose circle tool and shape undo/redo controls in the toolbar

## Testing
- `npm test`
- `npm run lint` *(fails: Lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a88d4d6e10832b84054586e47cea40