### PR TITLE
chore: update tab title and remove favicon

### DIFF
--- a/teammapper-frontend/src/index.html
+++ b/teammapper-frontend/src/index.html
@@ -3,7 +3,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>TeamMapper</title>
+    <title>MindMapper</title>
     <base href="/" />
     <meta
       content="width=device-width, initial-scale=1, maximum-scale=1"
@@ -28,24 +28,6 @@
         style-src 'self' 'unsafe-inline';
         img-src 'self' https://static.arasaac.org data:;
         " />
-    <link
-      href="./assets/icons/icon-72x72.png"
-      rel="icon"
-      sizes="72x72"
-      type="image/png" />
-    <link
-      href="./assets/icons/icon-192x192.png"
-      rel="icon"
-      sizes="192x192"
-      type="image/png" />
-    <link
-      href="./assets/icons/icon-128x128.png"
-      rel="apple-touch-icon"
-      sizes="128x128" />
-    <link
-      rel="icon"
-      href="./assets/icons/teammapper.svg"
-      type="image/svg+xml" />
   </head>
 
   <body>


### PR DESCRIPTION
## Summary
- display MindMapper in browser tab
- remove tab favicon to drop TeamMapper logo

## Testing
- `npm --prefix teammapper-frontend run build:packages`
- `npm --prefix teammapper-frontend test`

------
https://chatgpt.com/codex/tasks/task_e_68b229bc4a40832b828e36fb5ec73cf3